### PR TITLE
fix: Repair crashlooping deployments: /home/node perms and glibc base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:26-slim AS base
+FROM node:26-bookworm-slim AS base
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -6,8 +6,11 @@ RUN apt-get update \
   && apt-get upgrade --assume-yes \
   && rm -rf /var/lib/apt/lists/*
 
+# Recent node base images ship /home/node with mode 0700. The Kubernetes
+# deployment runs the container as a non-node UID, which then cannot traverse
+# /home/node to reach the app. Restore world traversal explicitly.
 USER node
-RUN mkdir /home/node/app
+RUN chmod go+rx /home/node && mkdir /home/node/app
 WORKDIR /home/node/app
 COPY --chown=node:node ./package.json ./package-lock.json ./
 
@@ -42,7 +45,7 @@ RUN npm run build
 
 # The base image should be the same as the base image of base. Yet using ARG for
 # the base image irritates hadolint and might break Dependabot.
-FROM node:26-slim AS production
+FROM node:26-bookworm-slim AS production
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV NODE_ENV=production
@@ -54,8 +57,11 @@ RUN apt-get update \
   'tini' \
   && rm -rf /var/lib/apt/lists/*
 
+# Recent node base images ship /home/node with mode 0700. The Kubernetes
+# deployment runs the container as a non-node UID, which then cannot traverse
+# /home/node to reach the app. Restore world traversal explicitly.
 USER node
-RUN mkdir /home/node/app
+RUN chmod go+rx /home/node && mkdir /home/node/app
 WORKDIR /home/node/app
 COPY \
   --chown=node:node \


### PR DESCRIPTION
## Problem

The prod `pulsar-mqtt-forwarder-rtpi` and `-raportointi` pods have been in CrashLoopBackOff for 27+ hours (staging: 8+ days) — the public anonymized-APC MQTT feed and the raportointi feed are down. They crash at startup with `Cannot find module '/home/node/app/dist/index.js'`.

Two independent problems in images built from the current base:

1. **`/home/node` mode 0700**: recent node images hardened the home directory; the deployments run as UID 10001, which cannot traverse `/home/node`. (Same as waltti-apc-anonymizer#726.)
2. **glibc 2.41 (trixie) native crashes**: `node:26-slim` silently moved from bookworm to trixie; on trixie the pulsar-client native library aborts/segfaults within minutes under load — verified empirically on the anonymizer, which is stable on bookworm builds and crashed every ~5–7 min on trixie builds. (Same as waltti-apc-anonymizer#729.)

## Changes

- `chmod go+rx /home/node` before creating the app dir, in both stages.
- Pin `node:26-bookworm-slim` for base and production stages until pulsar-client is verified clean on trixie/glibc 2.41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)